### PR TITLE
Bump tokio to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ async = ["tokio"]
 
 [dependencies]
 chrono = "^0.4.10"
-tokio = { version = "^0.2.9", features = ["udp", "dns", "time"], optional = true }
+tokio = { version = "^1.0", features = ["net", "time"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ impl AsyncSntpClient {
     ) -> Result<SynchronizationResult, SynchroniztationError> {
         let mut receive_buffer = [0; Packet::ENCODED_LEN];
 
-        let mut socket = tokio::net::UdpSocket::bind(self.bind_address).await?;
+        let socket = tokio::net::UdpSocket::bind(self.bind_address).await?;
         socket
             .connect(server_address.to_server_addrs(SNTP_PORT))
             .await?;


### PR DESCRIPTION
This might be a breaking change, dependents should be also updated to
use Tokio 1.0. This fixes issue #1 