### PR TITLE
Optional time crate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,17 @@ authors = ["Szilveszter Dobák <dobaksz@gmail.com>"]
 repository = "https://github.com/dobaksz/rsntp"
 documentation = "https://docs.rs/rsntp"
 edition = "2021"
-keywords = ["sntp", "time", "async"] 
+keywords = ["sntp", "time", "async"]
 categories = ["network-programming"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "An RFC 4330 compliant Simple Network Time Protocol (SNTP) client library for Rust"
 
 [features]
-default = ["async"]
+default = ["async", "chrono"]
 async = ["tokio"]
 
 [dependencies]
-chrono = "^0.4.10"
+chrono = { version = "^0.4.10", optional = true }
+time = { version = "^0.3.7", optional = true }
 tokio = { version = "^1.0", features = ["net", "time"], optional = true }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ library for Rust.
 `rsntp` provides an API to synchronize time with SNTPv4 time servers with the following features:
 
 * Provides both a synchronous (blocking) and an (optional) asynchronous API based `tokio`
-* Time and date handling based on the `chrono` crate
+* Time and date handling based either on the `chrono` or `time` crates
 * IPv6 support
 
 

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -2,19 +2,19 @@ fn main() {
     let client = rsntp::SntpClient::new();
     let time_info = client.synchronize("pool.ntp.org").unwrap();
 
-    println!(
-        "Clock offset: {} ms",
-        time_info.clock_offset().num_milliseconds()
-    );
-    println!(
-        "Round trip delay: {} ms",
-        time_info.round_trip_delay().num_milliseconds()
-    );
-    println!("Server timestamp: {}", time_info.datetime().to_string());
+    #[cfg(feature = "chrono")]
+    let clock_offset = time_info.clock_offset().num_milliseconds();
+    #[cfg(feature = "time")]
+    let clock_offset = time_info.clock_offset().whole_milliseconds();
+    println!("Clock offset: {} ms", clock_offset);
 
-    println!(
-        "Reference identifier: {}",
-        time_info.reference_identifier().to_string()
-    );
+    #[cfg(feature = "chrono")]
+    let round_trip_delay = time_info.round_trip_delay().num_milliseconds();
+    #[cfg(feature = "time")]
+    let round_trip_delay = time_info.round_trip_delay().whole_milliseconds();
+    println!("Round trip delay: {} ms", round_trip_delay);
+    println!("Server timestamp: {}", time_info.datetime());
+
+    println!("Reference identifier: {}", time_info.reference_identifier());
     println!("Stratum: {}", time_info.stratum());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! `rsntp` provides an API to synchronize time with SNTPv4 time servers with the following features:
 //!
 //! * Provides both a synchronous (blocking) and an (optional) asynchronous API based `tokio`
-//! * Time and date handling based on the `chrono` crate
+//! * Time and date handling based either on the `chrono` or `time` crates
 //! * IPv6 support
 //!
 //! ## Usage
@@ -80,6 +80,11 @@ rsntp = { version = "2.1.0", default-features = false }
 //! let local_time: DateTime<Local> = DateTime::from(result.datetime());
 //! ```
 //!
+
+#[cfg(all(feature = "chrono", feature = "time"))]
+compile_error!("rsntp can only be compiled with one of the following features: `chrono`, `time`");
+#[cfg(not(any(feature = "chrono", feature = "time")))]
+compile_error!("rsntp requires at least one of the following features: `chrono`, `time`");
 
 mod core_logic;
 mod error;


### PR DESCRIPTION
This adds optional support for the `time` crate through a feature. `chrono` is still default, though. All tests past (besides doc tests, but I don't feel like converting those)