### PR TITLE
allow ntp server from multicast

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+/* based on
+   https://discourse.nixos.org/t/how-can-i-set-up-my-rust-programming-environment/4501/9
+*/
+let
+  rust_overlay = import (builtins.fetchTarball
+    "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
+  pkgs = import <nixpkgs> { overlays = [ rust_overlay ]; };
+  rustVersion = "latest";
+  #rustVersion = "1.62.0";
+  rust = pkgs.rust-bin.stable.${rustVersion}.default.override {
+    extensions = [
+      "rust-src" # for rust-analyzer
+      "rust-analyzer"
+    ];
+  };
+in pkgs.mkShell {
+  buildInputs = [ rust ] ++ (with pkgs; [
+    pkg-config
+    protobuf_28
+    # other dependencies
+    #gtk3
+    #wrapGAppsHook
+  ]);
+  RUST_BACKTRACE = 1;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,12 +308,11 @@ impl SntpClient {
         let socket = std::net::UdpSocket::bind(self.config.bind_address)?;
 
         socket.set_read_timeout(Some(self.config.timeout))?;
-        socket.connect(server_address.to_server_addrs(SNTP_PORT))?;
 
         let request = Request::new();
         let mut receive_buffer = [0; Packet::ENCODED_LEN];
 
-        socket.send(&request.as_bytes())?;
+        socket.send_to(&request.as_bytes(), server_address.to_server_addrs(SNTP_PORT))?;
         let (bytes_received, server_address) = socket.recv_from(&mut receive_buffer)?;
 
         let reply = Reply::new(
@@ -452,12 +451,10 @@ impl AsyncSntpClient {
         let mut receive_buffer = [0; Packet::ENCODED_LEN];
 
         let socket = tokio::net::UdpSocket::bind(self.config.bind_address).await?;
-        socket
-            .connect(server_address.to_server_addrs(SNTP_PORT))
-            .await?;
+
         let request = Request::new();
 
-        socket.send(&request.as_bytes()).await?;
+        socket.send_to(&request.as_bytes(), server_address.to_server_addrs(SNTP_PORT)).await?;
 
         let result_future = timeout(self.config.timeout, socket.recv_from(&mut receive_buffer));
 


### PR DESCRIPTION
But one thing was missing. We have a setup of multiple devices which have a local [ntpd-rs](https://github.com/pendulum-project/ntpd-rs) server. This server can be reached with ipv6 multicast address. Unfortunately this doesn't currently work in your project. In order for it to work, I needed to remove the .connect() and use the .send_to() in the .syncronize() method.
As far as I understand the issue if you connect a UDP port to a address, it will only accept messages from the address. In our case, we send to a multicast address and listen to another address, since the server address is not the same as the multicast.

Is the .connect() required or can it be changed?
If it is required, some additional function like syncronise_to or something like this could be implemented.